### PR TITLE
fix(docker): add multi-arch (amd64/arm64) Docker build support

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      # Enable multi-architecture builds via QEMU emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Enable advanced Docker build features (required for caching)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -64,6 +68,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_VERSION=${{ env.RELEASE_TAG }}
           tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMRKIT_REPOSITORY_NAME }}:${{ env.RELEASE_TAG }}
           cache-from: type=registry,ref=${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMRKIT_REPOSITORY_NAME }}:buildcache

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -82,6 +82,7 @@ jobs:
           context: ./app/scripts/nmr-cli/
           file: ./app/scripts/nmr-cli/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_VERSION=${{ env.RELEASE_TAG }}
           tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMR_CLI_REPOSITORY_NAME }}:${{ env.RELEASE_TAG }}
           cache-from: type=registry,ref=${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMR_CLI_REPOSITORY_NAME }}:buildcache

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -118,6 +118,7 @@ jobs:
           context: ./app/scripts/nmr-cli/
           file: ./app/scripts/nmr-cli/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_VERSION=${{ env.RELEASE_TAG }}
           tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMR_CLI_REPOSITORY_NAME }}:${{ env.RELEASE_TAG }}
           cache-from: type=registry,ref=${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMR_CLI_REPOSITORY_NAME }}:buildcache

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -73,6 +73,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      # Enable multi-architecture builds via QEMU emulation
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Enable advanced Docker build features (required for caching)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -100,6 +104,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_VERSION=${{ env.RELEASE_TAG }}
           tags: ${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMRKIT_REPOSITORY_NAME }}:${{ env.RELEASE_TAG }}
           cache-from: type=registry,ref=${{ env.REPOSITORY_NAMESPACE }}/${{ env.NMRKIT_REPOSITORY_NAME }}:buildcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM continuumio/miniconda3:24.1.2-0 AS nmrkit-ms
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 ENV PYTHON_VERSION=3.10
 ENV OPENBABEL_VERSION=v3.1
@@ -32,7 +32,6 @@ RUN pip3 install rdkit
 RUN python3 -m pip install -U pip
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}/
-RUN export JAVA_HOME
 
 RUN git clone "https://github.com/rinikerlab/lightweight-registration.git" lwreg
 RUN chmod +x lwreg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM continuumio/miniconda3:24.1.2-0 AS nmrkit-ms
+ARG TARGETARCH
 
 ENV PYTHON_VERSION=3.10
 ENV OPENBABEL_VERSION=v3.1
@@ -30,7 +31,7 @@ RUN pip3 install rdkit
 
 RUN python3 -m pip install -U pip
 
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}/
 RUN export JAVA_HOME
 
 RUN git clone "https://github.com/rinikerlab/lightweight-registration.git" lwreg


### PR DESCRIPTION
Problem: The `nmrkit` Docker image only works on amd64 machines right now. It doesn't run on arm64 machines, like Apple Silicon Mac (M2) etc. [houdini69](https://github.com/houdini69) on #110 ran into this issue and just want `nmrkit` to work on his machine.

What change in this PR:
- `Dockerfile`: `JAVA_HOME` is hardcoded to `.../java-17-openjdk-amd64/`, which would silently point at a non-existent path when built for arm64 (Debian installs the arm64 JDK under `.../java-17-openjdk-arm64/`). Added `ARG TARGETARCH` and switched the path to use it, so it resolves correctly per architecture.
- `dev-build.yml` / `prod-build.yml`: added a `docker/setup-qemu-action@v3` step (needed so GitHub's amd64 runners can emulate arm64 during the build) and `platforms: linux/amd64,linux/arm64` on the main `nmrkit` image build step.

Testing: Verified the Dockerfile still builds locally for amd64. Haven't been able to test the arm64 build itself locally which will need to run in CI.

@NishaSharma14: New to this repo! It would be nice if you please review it.